### PR TITLE
fix(tests): added more protocol buffer tests

### DIFF
--- a/testdata/cat.proto
+++ b/testdata/cat.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package cats;
+
+option go_package = "github.com/protocolbuffers/protobuf/examples/go/tutorialpb";
+
+message Cat {
+  string name = 1;
+  int32 age = 2;
+}

--- a/testdata/cat.yml
+++ b/testdata/cat.yml
@@ -1,0 +1,15 @@
+
+#
+# Example format file
+#
+
+protocol_buffer_definitions:
+  - cat.proto
+protocol_buffer_paths:
+  - testdata/
+
+
+columns:
+  c2:
+    encoding: ProtocolBuffer
+    type: cats.Cat

--- a/valueformatting.go
+++ b/valueformatting.go
@@ -170,14 +170,16 @@ func (formatting *valueFormatting) pbFormatter(ctype string) (valueFormatter, er
 	return func(in []byte) (string, error) {
 		message := dynamic.NewMessage(md)
 		err := message.Unmarshal(in)
-		if err == nil {
-			data, err := message.MarshalTextIndent()
-			if err == nil {
-				return string(data), nil
-			}
+		if err != nil {
+			return "", fmt.Errorf("couldn't deserialize bytes to protobuffer message: %v", err)
 		}
 
-		return "", err
+		data, err := message.MarshalTextIndent()
+		if err != nil {
+			return "", fmt.Errorf("couldn't serialize message to bytes: %v", err)
+		}
+
+		return string(data), nil
 	}, nil
 }
 

--- a/valueformatting_test.go
+++ b/valueformatting_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -517,6 +518,46 @@ func TestValueFormattingFormat(t *testing.T) {
 			t.Errorf("Values formatted incorrectly: wanted %s, got %s", want,
 				got)
 		}
+	}
+}
+
+func TestProtobuffer(t *testing.T) {
+
+	globalValueFormatting = newValueFormatting()
+	globalValueFormatting.settings.ProtocolBufferDefinitions =
+		[]string{filepath.Join("testdata", "cat.proto")}
+	globalValueFormatting.settings.Columns["cat"] =
+		valueFormatColumn{Encoding: "ProtocolBuffer"}
+	globalValueFormatting.setup(map[string]string{})
+
+	row := bigtable.Row{
+		"f1": {
+			bigtable.ReadItem{
+				Row:    "r1",
+				Column: "f1:cat",
+				Value:  []byte("\n\x05Brave\x10\x02"),
+			},
+		},
+	}
+	var out bytes.Buffer
+
+	printRow(row, &out)
+	got := out.String()
+	want := ("----------------------------------------\n" +
+		"r1\n" +
+		"  f1:cat\n" +
+		"    name: \"Brave\"\n" +
+		"    age: 2")
+
+	timestampsRE := regexp.MustCompile("[ ]+@ [^ \t\n]+")
+
+	stripTimestamps := func(s string) string {
+		return string(timestampsRE.ReplaceAll([]byte(s), []byte("")))
+	}
+	got = stripTimestamps(got)
+
+	if !strings.Contains(got, want) {
+		t.Errorf("Formatting printed incorrectly: wanted\n%s\n,\ngot\n%s", want, got)
 	}
 }
 


### PR DESCRIPTION
The cbt CLI requires customers to provide a YAML "format file" in order to properly format protocol buffer data types. This PR adds more testing around this feature.