### PR TITLE
chore: Bigtable client deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module cloud.google.com/go/cbt
 go 1.17
 
 require (
-	cloud.google.com/go/bigtable v1.13.0
+	cloud.google.com/go/bigtable v1.13.1
 	github.com/google/go-cmp v0.5.8
 	github.com/jhump/protoreflect v1.12.0 // Third-party dependency; proceed with caution
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module cloud.google.com/go/cbt
 go 1.17
 
 require (
-	cloud.google.com/go/bigtable v1.13.1
+	cloud.google.com/go/bigtable v1.14.0
 	github.com/google/go-cmp v0.5.8
 	github.com/jhump/protoreflect v1.12.0 // Third-party dependency; proceed with caution
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401


### PR DESCRIPTION
This should hopefully remove the submodule version of cbt from the Golang package manager.