### PR TITLE
chore: remove yoshi-go-admins owners from repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*		@googleapis/yoshi-go-admins @telpirion @enocom @triplequark @igorbernstein2
+*		@telpirion @enocom @triplequark @igorbernstein2


### PR DESCRIPTION
We don't really do anything in this repo so removing us as CO's to reduce noise.