### PR TITLE
bugfix: time.Add usage in doSnapshotTable

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -1608,7 +1608,7 @@ func doSnapshotTable(ctx context.Context, args ...string) {
 	}
 
 	t := time.Now()
-	t.Add(ttl)
+	t = t.Add(ttl)
 
 	err = getAdminClient().CreateBackup(ctx, tableName, clusterName, snapshotName, t)
 	if err != nil {


### PR DESCRIPTION
`time.Add` Does not modify the instance and instead returns a copy with the addition applied.  This fix uses the copy.