### PR TITLE
refactor: Mark Snapshot commands as deprecated

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -465,7 +465,7 @@ var commands = []struct {
 	},
 	{
 		Name: "createsnapshot",
-		Desc: "Create a backup from a source table",
+		Desc: "Create a backup from a source table (deprecated)",
 		do:   doSnapshotTable,
 		Usage: "cbt createsnapshot <cluster> <backup> <table> [ttl=<d>]\n" +
 			`  [ttl=<d>]        Lifespan of the backup (e.g. "1h", "4d")`,
@@ -486,7 +486,7 @@ var commands = []struct {
 	},
 	{
 		Name: "createtablefromsnapshot",
-		Desc: "Create a table from a backup",
+		Desc: "Create a table from a backup (deprecated)",
 		do:   doCreateTableFromSnapshot,
 		Usage: "cbt createtablefromsnapshot <table> <cluster> <backup>\n" +
 			"  table        The name of the table to create\n" +
@@ -554,7 +554,7 @@ var commands = []struct {
 	},
 	{
 		Name:     "deletesnapshot",
-		Desc:     "Delete snapshot in a cluster",
+		Desc:     "Delete snapshot in a cluster (deprecated)",
 		do:       doDeleteSnapshot,
 		Usage:    "cbt deletesnapshot <cluster> <backup>",
 		Required: ProjectAndInstanceRequired,
@@ -583,7 +583,7 @@ var commands = []struct {
 	},
 	{
 		Name:     "getsnapshot",
-		Desc:     "Get backups info ",
+		Desc:     "Get backups info (deprecated)",
 		do:       doGetSnapshot,
 		Usage:    "cbt getsnapshot <cluster> <backup>",
 		Required: ProjectAndInstanceRequired,
@@ -646,7 +646,7 @@ var commands = []struct {
 	},
 	{
 		Name:     "listsnapshots",
-		Desc:     "List backups in a cluster",
+		Desc:     "List backups in a cluster (deprecated)",
 		do:       doListSnapshots,
 		Usage:    "cbt listsnapshots [<cluster>]",
 		Required: ProjectAndInstanceRequired,
@@ -1585,6 +1585,7 @@ func parseStorageType(storageTypeStr string) (bigtable.StorageType, error) {
 
 // NOTE: Previous version of this feature was called "snapshots"
 func doCreateTableFromSnapshot(ctx context.Context, args ...string) {
+	log.Println("Warning: This command is deprecated. Please use gcloud instead. Usage info: gcloud bigtable instances tables restore --help")
 	if len(args) != 3 {
 		log.Fatal("usage: cbt createtablefromsnapshot <table> <cluster> <backup>")
 	}
@@ -1601,6 +1602,7 @@ func doCreateTableFromSnapshot(ctx context.Context, args ...string) {
 
 // NOTE: Previous version of this feature was called "snapshots"
 func doSnapshotTable(ctx context.Context, args ...string) {
+	log.Println("Warning: This command is deprecated. Please use gcloud instead. Usage info: gcloud bigtable backups create --help")
 	if len(args) != 3 && len(args) != 4 {
 		log.Fatal("usage: cbt createsnapshot <cluster> <backup> <table> [ttl=<d>]")
 	}
@@ -1632,6 +1634,7 @@ func doSnapshotTable(ctx context.Context, args ...string) {
 
 // NOTE: Previous version of this feature was called "snapshots"
 func doListSnapshots(ctx context.Context, args ...string) {
+	log.Println("Warning: This command is deprecated. Please use gcloud instead. Usage info: gcloud bigtable backups list --help")
 	if len(args) != 0 && len(args) != 1 {
 		log.Fatal("usage: cbt listsnapshots [<cluster>]")
 	}
@@ -1666,6 +1669,7 @@ func doListSnapshots(ctx context.Context, args ...string) {
 
 // NOTE: Previous version of this feature was called "snapshots"
 func doGetSnapshot(ctx context.Context, args ...string) {
+	log.Println("Warning: This command is deprecated. Please use gcloud instead. Usage info: gcloud bigtable backups describe --help")
 	if len(args) != 2 {
 		log.Fatalf("usage: cbt getsnapshot <cluster> <backup>")
 	}
@@ -1687,6 +1691,7 @@ func doGetSnapshot(ctx context.Context, args ...string) {
 
 // NOTE: Previous version of this feature was called "snapshots"
 func doDeleteSnapshot(ctx context.Context, args ...string) {
+	log.Println("Warning: This command is deprecated. Please use gcloud instead. Usage info: gcloud bigtable backups delete --help")
 	if len(args) != 2 {
 		log.Fatal("usage: cbt deletesnapshot <cluster> <backup>")
 	}

--- a/cbtdoc.go
+++ b/cbtdoc.go
@@ -35,9 +35,9 @@ The commands are:
 	createcluster             Create a cluster in the configured instance
 	createfamily              Create a column family
 	createinstance            Create an instance with an initial cluster
-	createsnapshot            Create a backup from a source table
+	createsnapshot            Create a backup from a source table (deprecated)
 	createtable               Create a table
-	createtablefromsnapshot   Create a table from a backup
+	createtablefromsnapshot   Create a table from a backup (deprecated)
 	deleteallrows             Delete all rows
 	deleteappprofile          Delete app profile for an instance
 	deletecluster             Delete a cluster from the configured instance
@@ -45,17 +45,17 @@ The commands are:
 	deletefamily              Delete a column family
 	deleteinstance            Delete an instance
 	deleterow                 Delete a row
-	deletesnapshot            Delete snapshot in a cluster
+	deletesnapshot            Delete snapshot in a cluster (deprecated)
 	deletetable               Delete a table
 	doc                       Print godoc-suitable documentation for cbt
 	getappprofile             Read app profile for an instance
-	getsnapshot               Get backups info
+	getsnapshot               Get backups info (deprecated)
 	help                      Print help text
 	import                    Batch write many rows based on the input file
 	listappprofile            Lists app profile for an instance
 	listclusters              List clusters in an instance
 	listinstances             List instances in a project
-	listsnapshots             List backups in a cluster
+	listsnapshots             List backups in a cluster (deprecated)
 	lookup                    Read from a single row
 	ls                        List tables and column families
 	mddoc                     Print documentation for cbt in Markdown format
@@ -273,7 +273,7 @@ Usage:
 
 	    Example: cbt createinstance my-instance "My instance" my-instance-c1 us-central1-b 3 SSD
 
-# Create a backup from a source table
+# Create a backup from a source table (deprecated)
 
 Usage:
 
@@ -293,7 +293,7 @@ Usage:
 
 	    Example: cbt createtable mobile-time-series "families=stats_summary:maxage=10d||maxversions=1,stats_detail:maxage=10d||maxversions=1" splits=tablet,phone
 
-# Create a table from a backup
+# Create a table from a backup (deprecated)
 
 Usage:
 
@@ -360,7 +360,7 @@ Usage:
 
 	    Example: cbt deleterow mobile-time-series phone#4c410523#20190501
 
-# Delete snapshot in a cluster
+# Delete snapshot in a cluster (deprecated)
 
 Usage:
 
@@ -386,7 +386,7 @@ Usage:
 
 	cbt getappprofile <instance-id> <profile-id>
 
-# Get backups info
+# Get backups info (deprecated)
 
 Usage:
 
@@ -448,7 +448,7 @@ Usage:
 
 	cbt listinstances
 
-# List backups in a cluster
+# List backups in a cluster (deprecated)
 
 Usage:
 


### PR DESCRIPTION
* refactor: Marking snapshot commands as deprecated. Printing warning directing users to use gcloud instead
* docs: updating documentation (snapshot commands marked as deprecated)