### PR TITLE
fix: set proper ttl in createsnapshot

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -1611,8 +1611,7 @@ func doSnapshotTable(ctx context.Context, args ...string) {
 		}
 	}
 
-	t := time.Now()
-	t.Add(ttl)
+	t := time.Now().Add(ttl)
 
 	err = getAdminClient().CreateBackup(ctx, tableName, clusterName, snapshotName, t)
 	if err != nil {


### PR DESCRIPTION
fix: set proper ttl in createsnapshot

ttl was not added to the expiration time and the Now ts was sent to the server. This leads to errors like "Expire time must be at least 6h from the time the backup was started, which should be XXX, but got XXXX"