### PR TITLE
feat: add timestamp support to cbt import

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -600,11 +600,12 @@ var commands = []struct {
 		Name: "import",
 		Desc: "Batch write many rows based on the input file",
 		do:   doImport,
-		Usage: "cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>]\n" +
+		Usage: "cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>] [timestamp=<now|value-encoded>]\n" +
 			"  app-profile=<app-profile-id>          The app profile ID to use for the request\n" +
 			"  column-family=<family-name>           The column family label to use\n" +
 			"  batch-size=<500>                      The max number of rows per batch write request\n" +
-			"  workers=<1>                           The number of worker threads\n\n" +
+			"  workers=<1>                           The number of worker threads\n" +
+			"  timestamp=<now|value-encoded>	     	Whether to use current time for all cells or interpret the timestamp from cell value. Defaults to 'now'.\n\n" +
 			"  Import data from a CSV file into an existing Cloud Bigtable table that already has the column families your data requires.\n\n" +
 			"  The CSV file can support two rows of headers:\n" +
 			"      - (Optional) column families\n" +
@@ -612,9 +613,9 @@ var commands = []struct {
 			"  Because the first column is reserved for row keys, leave it empty in the header rows.\n" +
 			"  In the column family header, provide each column family once; it applies to the column it is in and every column to the right until another column family is found.\n" +
 			"  Each row after the header rows should contain a row key in the first column, followed by the data cells for the row.\n" +
-			"  See the example below. If you don't provide a column family header row, the column header is your first row and your import command must include the `column-family` flag to specify an existing column family. \n" +
-			"  The timestamp for each cell will default to current time, to explicitly set the timestamp for a cell, use <val>[@<timestamp>] as the value for the cell.\n" +
-			"  If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.\n" +
+			"  See the example below. If you don't provide a column family header row, the column header is your first row and your import command must include the `column-family` flag to specify an existing column family. \n\n" +
+			"  The timestamp for each cell will default to current time (timestamp=now), to explicitly set the timestamp for cells, set timestamp=value-encoded use <val>[@<timestamp>] as the value for the cell.\n" +
+			"  If no timestamp is delimited for a cell, current time will be used. If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.\n" +
 			"  For most uses, a timestamp is the number of microseconds since 1970-01-01 00:00:00 UTC.\n\n" +
 			"    ,column-family-1,,column-family-2,      // Optional column family row (1st cell empty)\n" +
 			"    ,column-1,column-2,column-3,column-4    // Column qualifiers row (1st cell empty)\n" +
@@ -1867,6 +1868,7 @@ type importerArgs struct {
 	fam        string
 	sz         int
 	workers    int
+	timestamp  string
 }
 
 type safeReader struct {
@@ -1893,12 +1895,13 @@ func doImport(ctx context.Context, args ...string) {
 func parseImporterArgs(ctx context.Context, args []string) (importerArgs, error) {
 	var err error
 	ia := importerArgs{
-		fam:     "",
-		sz:      500,
-		workers: 1,
+		fam:       "",
+		sz:        500,
+		workers:   1,
+		timestamp: "now",
 	}
 	if len(args) < 2 {
-		return ia, fmt.Errorf("usage: cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>]")
+		return ia, fmt.Errorf("usage: cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>] [timestamp=<now|value-encoded>]")
 	}
 	for _, arg := range args[2:] {
 		switch {
@@ -1919,6 +1922,11 @@ func parseImporterArgs(ctx context.Context, args []string) (importerArgs, error)
 			if err != nil || ia.workers <= 0 {
 				return ia, fmt.Errorf("workers must be > 0, err:%s", err)
 			}
+		case strings.HasPrefix(arg, "timestamp="):
+			ia.timestamp = strings.Split(arg, "=")[1]
+			if ia.timestamp != "now" && ia.timestamp != "value-encoded" {
+				return ia, fmt.Errorf("timestamp must be one of 'now' or 'value-encoded'")
+			}
 		}
 	}
 	return ia, nil
@@ -1937,7 +1945,7 @@ func importCSV(ctx context.Context, tbl *bigtable.Table, r *csv.Reader, ia impor
 	for i := 0; i < ia.workers; i++ {
 		go func(w int) {
 			defer wg.Done()
-			if e := sr.parseAndWrite(ctx, tbl, fams, cols, ts, ia.sz, w); e != nil {
+			if e := sr.parseAndWrite(ctx, tbl, ia.timestamp, fams, cols, ts, ia.sz, w); e != nil {
 				log.Fatalf("error: %s", e)
 			}
 		}(i)
@@ -1993,7 +2001,7 @@ func batchWrite(ctx context.Context, tbl *bigtable.Table, rk []string, muts []*b
 	return len(rk), nil
 }
 
-func (sr *safeReader) parseAndWrite(ctx context.Context, tbl *bigtable.Table, fams, cols []string, ts bigtable.Timestamp, max, worker int) error {
+func (sr *safeReader) parseAndWrite(ctx context.Context, tbl *bigtable.Table, tstype string, fams, cols []string, ts bigtable.Timestamp, max, worker int) error {
 	var rowKey []string
 	var muts []*bigtable.Mutation
 	var c int
@@ -2012,12 +2020,14 @@ func (sr *safeReader) parseAndWrite(ctx context.Context, tbl *bigtable.Table, fa
 			for i, val := range line {
 				if i > 0 && val != "" {
 					setts := ts
-					if i := strings.LastIndex(val, "@"); i >= 0 {
-						// Try parsing a timestamp.
-						n, err := strconv.ParseInt(val[i+1:], 0, 64)
-						if err == nil {
-							val = val[:i]
-							setts = bigtable.Timestamp(n)
+					if tstype == "value-encoded" {
+						if i := strings.LastIndex(val, "@"); i >= 0 {
+							// Try parsing a timestamp.
+							n, err := strconv.ParseInt(val[i+1:], 0, 64)
+							if err == nil {
+								val = val[:i]
+								setts = bigtable.Timestamp(n)
+							}
 						}
 					}
 					mut.Set(fams[i], cols[i], setts, []byte(val))

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -430,6 +431,11 @@ func validateData(ctx context.Context, tbl *bigtable.Table, fams, cols []string,
 			for _, column := range cf {
 				k := data[0] + ":" + string(column.Column)
 				v, ok := valMap[k]
+				if i := strings.LastIndex(v, "@"); i >= 0 {
+					if _, err := strconv.ParseInt(v[i+1:], 0, 64); err == nil {
+						v = v[:i]
+					}
+				}
 				if ok && v == string(column.Value) {
 					delete(valMap, k)
 				}
@@ -451,6 +457,8 @@ func TestCsvParseAndWrite(t *testing.T) {
 	rowData := [][]string{
 		{"rk-0", "A", "B"},
 		{"rk-1", "", "C"},
+		{"rk-2", "D@1577862000000000", ""},
+		{"rk-3", "", "E@055000"},
 	}
 
 	byteData, err := transformToCsvBuffer(rowData)

--- a/cbtdoc.go
+++ b/cbtdoc.go
@@ -419,12 +419,16 @@ Usage:
 	  In the column family header, provide each column family once; it applies to the column it is in and every column to the right until another column family is found.
 	  Each row after the header rows should contain a row key in the first column, followed by the data cells for the row.
 	  See the example below. If you don't provide a column family header row, the column header is your first row and your import command must include the `column-family` flag to specify an existing column family.
+	  The timestamp for each cell will default to current time, to explicitly set the timestamp for a cell, use <val>[@<timestamp>] as the value for the cell.
+	  If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.
+	  For most uses, a timestamp is the number of microseconds since 1970-01-01 00:00:00 UTC.
 
 	    ,column-family-1,,column-family-2,      // Optional column family row (1st cell empty)
 	    ,column-1,column-2,column-3,column-4    // Column qualifiers row (1st cell empty)
 	    a,TRUE,,,FALSE                          // Rowkey 'a' followed by data
 	    b,,,TRUE,FALSE                          // Rowkey 'b' followed by data
 	    c,,TRUE,,TRUE                           // Rowkey 'c' followed by data
+	    d,TRUE@1577862000000000,,,FALSE		 	// Rowkey 'd' followed by data
 
 	  Examples:
 	    cbt import csv-import-table data.csv

--- a/cbtdoc.go
+++ b/cbtdoc.go
@@ -404,11 +404,12 @@ Usage:
 
 Usage:
 
-	cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>]
+	cbt import <table-id> <input-file> [app-profile=<app-profile-id>] [column-family=<family-name>] [batch-size=<500>] [workers=<1>] [timestamp=<now|value-encoded>]
 	  app-profile=<app-profile-id>          The app profile ID to use for the request
 	  column-family=<family-name>           The column family label to use
 	  batch-size=<500>                      The max number of rows per batch write request
 	  workers=<1>                           The number of worker threads
+	  timestamp=<now|value-encoded>	     	Whether to use current time for all cells or interpret the timestamp from cell value. Defaults to 'now'.
 
 	  Import data from a CSV file into an existing Cloud Bigtable table that already has the column families your data requires.
 
@@ -419,8 +420,9 @@ Usage:
 	  In the column family header, provide each column family once; it applies to the column it is in and every column to the right until another column family is found.
 	  Each row after the header rows should contain a row key in the first column, followed by the data cells for the row.
 	  See the example below. If you don't provide a column family header row, the column header is your first row and your import command must include the `column-family` flag to specify an existing column family.
-	  The timestamp for each cell will default to current time, to explicitly set the timestamp for a cell, use <val>[@<timestamp>] as the value for the cell.
-	  If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.
+
+	  The timestamp for each cell will default to current time (timestamp=now), to explicitly set the timestamp for cells, set timestamp=value-encoded use <val>[@<timestamp>] as the value for the cell.
+	  If no timestamp is delimited for a cell, current time will be used. If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.
 	  For most uses, a timestamp is the number of microseconds since 1970-01-01 00:00:00 UTC.
 
 	    ,column-family-1,,column-family-2,      // Optional column family row (1st cell empty)


### PR DESCRIPTION
This PR adds the timestamp parsing capability from `cbt set` to csv cell values in `cbt import` & updates the docs. I have included the background and an example below.

<details>
<summary>Background</summary>

We are currently in process of migrating several large, production datasets from mySQL to Bigtable. Currently, we have test data for mysql stored in a .sql file that is applied in a bash script that runs on startup in our testing environments. As we migrate to Bigtable, we need the test data to be loaded into our Bigtable emulator in a similar way, and we need timestamp data to be specified.

`cbt import` easily gives us the ability to bulk write the data to our emulator, but doesn't currently apply timestamps the way that `cbt set` does.
</details>

<details>
<summary>Example</summary>
This PR uses the same logic from cbt set. Build this branch and run the following with the attached csv for an example:

```bash
#!/bin/bash

export BIGTABLE_EMULATOR_HOST=''
PROJECT=''
INSTANCE=''
TABLE='test-table'

cbt -project=$PROJECT -instance=$INSTANCE createtable $TABLE
cbt -project=$PROJECT -instance=$INSTANCE createfamily $TABLE A
cbt -project=$PROJECT -instance=$INSTANCE createfamily $TABLE B
cbt -project=$PROJECT -instance=$INSTANCE createfamily $TABLE C

cbt -project=$PROJECT -instance=$INSTANCE import $TABLE test-table-data.csv timestamp=value-encoded
```

[test-table-data.csv](https://github.com/googleapis/cloud-bigtable-cbt-cli/files/11519263/test-table-data.csv)

Note that not all columns in this example have a specified timestamp, and the current time (current behavior) is used.

</details>
