### PR TITLE
feat: Support arbitrary bytes as a value to `cbt set`

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -734,9 +734,11 @@ var commands = []struct {
 			"    timestamp is an optional integer. \n" +
 			"    If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.\n" +
 			"    For most uses, a timestamp is the number of microseconds since 1970-01-01 00:00:00 UTC.\n\n" +
+			"    val is a string, and arbitrary bytes can be passed using the $'<byte-data>' bash construct.\n\n" +
 			"    Examples:\n" +
 			"      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:connected_cell=1@12345 stats_summary:connected_cell=0@1570041766\n" +
-			"      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:os_build=PQ2A.190405.003 stats_summary:os_name=android",
+			"      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:os_build=PQ2A.190405.003 stats_summary:os_name=android\n" +
+			"      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:serial_nr_bytes=$'\\x00\\x01\\x02\\x03'",
 		Required: ProjectAndInstanceRequired,
 	},
 	{
@@ -1515,7 +1517,7 @@ func doRead(ctx context.Context, args ...string) {
 	}
 }
 
-var setArg = regexp.MustCompile(`([^:]+):([^=]*)=(.*)`)
+var setArg = regexp.MustCompile(`([^:]+):([^=]*)=(?s)(.*)`)
 
 func doSet(ctx context.Context, args ...string) {
 	if len(args) < 3 {

--- a/cbtdoc.go
+++ b/cbtdoc.go
@@ -534,9 +534,12 @@ Usage:
 	    If the timestamp cannot be parsed, '@<timestamp>' will be interpreted as part of the value.
 	    For most uses, a timestamp is the number of microseconds since 1970-01-01 00:00:00 UTC.
 
+	    val is a string, and arbitrary bytes can be passed using the $'<byte-data>' bash construct.
+
 	    Examples:
 	      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:connected_cell=1@12345 stats_summary:connected_cell=0@1570041766
 	      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:os_build=PQ2A.190405.003 stats_summary:os_name=android
+	      cbt set mobile-time-series phone#4c410523#20190501 stats_summary:serial_nr_bytes=$'\x00\x01\x02\x03'
 
 # Set the garbage-collection policy (age, versions) for a column family
 


### PR DESCRIPTION
The way `cbt set` was previously parsing the value from arguments didn't accommodate newlines, meaning that if a byte string was supplied that happened to contain a `\n (\x0a)` the value would be truncated at that point before setting, so such values were not possible to set properly using cbt.

With this change, arbitrary byte strings can be set provided shell escaping is done correctly (using `$'<bytes>'`, for example).
