### PR TITLE
fix: parsing of qualifiers with colons

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -2163,10 +2163,10 @@ func parseColumnsFilter(columns string) (bigtable.Filter, error) {
 }
 
 func columnFilter(column string) (bigtable.Filter, error) {
-	splitColumn := strings.Split(column, ":")
+	splitColumn := strings.SplitN(column, ":", 2)
 	if len(splitColumn) == 1 {
 		return bigtable.ColumnFilter(splitColumn[0]), nil
-	} else if len(splitColumn) == 2 {
+	} else {
 		if strings.HasSuffix(column, ":") {
 			return bigtable.FamilyFilter(splitColumn[0]), nil
 		} else if strings.HasPrefix(column, ":") {
@@ -2176,8 +2176,6 @@ func columnFilter(column string) (bigtable.Filter, error) {
 			qualifierFilter := bigtable.ColumnFilter(splitColumn[1])
 			return bigtable.ChainFilters(familyFilter, qualifierFilter), nil
 		}
-	} else {
-		return nil, fmt.Errorf("bad format for column %q", column)
 	}
 }
 

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -178,12 +178,12 @@ func TestParseColumnsFilter(t *testing.T) {
 			),
 		},
 		{
-			in:   "familyA:columnA:cellA",
-			fail: true,
+			in:  "familyA:columnA:text",
+			out: bigtable.ChainFilters(bigtable.FamilyFilter("familyA"), bigtable.ColumnFilter("columnA:text")),
 		},
 		{
-			in:   "familyA::columnA",
-			fail: true,
+			in:  "familyA::columnA",
+			out: bigtable.ChainFilters(bigtable.FamilyFilter("familyA"), bigtable.ColumnFilter(":columnA")),
 		},
 	}
 


### PR DESCRIPTION
The way column qualifiers are being parsed atm doesn't take into account those containing colon characters.

E.g.: given a column name `abc:def:ghi`, `columnFilter()`  throws a _bad format for column_ message, instead of returning a filter chain of `abc` and `def:ghi`