### PR TITLE
fix: Don't set a GC policy on new column families by default

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -845,8 +845,7 @@ func doCreateTable(ctx context.Context, args ...string) {
 				famPolicy := strings.Split(family, ":")
 				var gcPolicy bigtable.GCPolicy
 				if len(famPolicy) < 2 {
-					gcPolicy = bigtable.MaxVersionsPolicy(1)
-					log.Printf("Using default GC Policy of %v for family %v", gcPolicy, family)
+					gcPolicy = bigtable.NoGcPolicy()
 				} else {
 					gcPolicy, err = parseGCPolicy(famPolicy[1])
 					if err != nil {


### PR DESCRIPTION
Per the GCP docs (https://cloud.google.com/bigtable/docs/garbage-collection#everything-else), the cbt CLI should not add a GC policy to newly created column families.  This corrects it to not do that.