### PR TITLE
fix: allow colons in column qualifier

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -2173,10 +2173,10 @@ func parseColumnsFilter(columns string) (bigtable.Filter, error) {
 }
 
 func columnFilter(column string) (bigtable.Filter, error) {
-	splitColumn := strings.Split(column, ":")
+	splitColumn := strings.SplitN(column, ":", 2)
 	if len(splitColumn) == 1 {
 		return bigtable.ColumnFilter(splitColumn[0]), nil
-	} else if len(splitColumn) == 2 {
+	} else {
 		if strings.HasSuffix(column, ":") {
 			return bigtable.FamilyFilter(splitColumn[0]), nil
 		} else if strings.HasPrefix(column, ":") {
@@ -2186,8 +2186,6 @@ func columnFilter(column string) (bigtable.Filter, error) {
 			qualifierFilter := bigtable.ColumnFilter(splitColumn[1])
 			return bigtable.ChainFilters(familyFilter, qualifierFilter), nil
 		}
-	} else {
-		return nil, fmt.Errorf("bad format for column %q", column)
 	}
 }
 

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -177,14 +177,6 @@ func TestParseColumnsFilter(t *testing.T) {
 				bigtable.ChainFilters(bigtable.FamilyFilter("familyB"), bigtable.ColumnFilter("columnB")),
 			),
 		},
-		{
-			in:   "familyA:columnA:cellA",
-			fail: true,
-		},
-		{
-			in:   "familyA::columnA",
-			fail: true,
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
I use colon (`:`) in column qualifiers, but `cbt` doesn't allow it. According to https://cloud.google.com/bigtable/docs/schema-design#columns, there seems no reason to disallow colon in column qualifier. This PR aims to allow `cbt` to specify colon as a part of column qualifier.