### PR TITLE
fix: printing timestamps that are higher than int64 max / 1e3

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -1415,7 +1415,7 @@ func printRow(r bigtable.Row, w io.Writer) {
 		ris := r[fam]
 		sort.Sort(byColumn(ris))
 		for _, ri := range ris {
-			ts := time.Unix(0, int64(ri.Timestamp)*1e3)
+			ts := time.UnixMicro(int64(ri.Timestamp))
 			fmt.Fprintf(w, "  %-40s @ %s\n",
 				ri.Column,
 				ts.Format("2006/01/02-15:04:05.000000"))

--- a/cbt.go
+++ b/cbt.go
@@ -1403,6 +1403,10 @@ func doLookup(ctx context.Context, args ...string) {
 }
 
 func printRow(r bigtable.Row, w io.Writer) {
+  printRowAtTimezone(r, w, time.Local)
+}
+
+func printRowAtTimezone(r bigtable.Row, w io.Writer, loc *time.Location) {
 	fmt.Fprintln(w, strings.Repeat("-", 40))
 	fmt.Fprintln(w, r.Key())
 
@@ -1418,7 +1422,7 @@ func printRow(r bigtable.Row, w io.Writer) {
 			ts := time.UnixMicro(int64(ri.Timestamp))
 			fmt.Fprintf(w, "  %-40s @ %s\n",
 				ri.Column,
-				ts.Format("2006/01/02-15:04:05.000000"))
+				ts.In(loc).Format("2006/01/02-15:04:05.000000"))
 			formatted, err :=
 				globalValueFormatting.format(
 					"    ", fam, ri.Column, ri.Value)

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -476,6 +476,27 @@ func TestCsvParseAndWrite(t *testing.T) {
 	}
 }
 
+func TestPrintRowWithHighTimestamp(t *testing.T) {
+	//var sb strings.Builder
+	ctx, client := setupEmulator(t, []string{"my-table"}, []string{"my-family"})
+	tbl := client.Open("my-table")
+	mut := bigtable.NewMutation()
+	// a timestamp that is just over int64 max in nanoseconds
+	mut.Set("my-family", "foo", 9223372036855000, []byte("bar"))
+	err := tbl.Apply(ctx, "my-key", mut)
+	if (err != nil) {
+		t.Fatalf("Could not write some rows to prepare the test.")
+	}
+	row, err := tbl.ReadRow(ctx, "my-key")
+	var sb strings.Builder
+	printRow(row, &sb)
+
+	expected := "@ 2262/04/11-19:47:16.855000"
+	if !strings.Contains(sb.String(), expected) {
+		t.Fatalf("Could not find correct timestamp string in printRow result.\nExpected a string containing: %s\nGot: %s", expected, sb.String())
+	}
+}
+
 func TestCsvParseAndWriteBadFamily(t *testing.T) {
 	ctx, client := setupEmulator(t, []string{"my-table"}, []string{"my-family"})
 

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -477,21 +477,26 @@ func TestCsvParseAndWrite(t *testing.T) {
 }
 
 func TestPrintRowWithHighTimestamp(t *testing.T) {
-	//var sb strings.Builder
 	ctx, client := setupEmulator(t, []string{"my-table"}, []string{"my-family"})
 	tbl := client.Open("my-table")
 	mut := bigtable.NewMutation()
+
+	loc, err := time.LoadLocation("US/Pacific")
+	if (err != nil) {
+		t.Fatalf("Failed to load timezone: %v", err)
+	}
+
 	// a timestamp that is just over int64 max in nanoseconds
 	mut.Set("my-family", "foo", 9223372036855000, []byte("bar"))
-	err := tbl.Apply(ctx, "my-key", mut)
+	err = tbl.Apply(ctx, "my-key", mut)
 	if (err != nil) {
 		t.Fatalf("Could not write some rows to prepare the test.")
 	}
 	row, err := tbl.ReadRow(ctx, "my-key")
 	var sb strings.Builder
-	printRow(row, &sb)
+	printRowAtTimezone(row, &sb, loc)
 
-	expected := "@ 2262/04/11-19:47:16.855000"
+	expected := "@ 2262/04/11-16:47:16.855000"
 	if !strings.Contains(sb.String(), expected) {
 		t.Fatalf("Could not find correct timestamp string in printRow result.\nExpected a string containing: %s\nGot: %s", expected, sb.String())
 	}


### PR DESCRIPTION
Before this PR, attempting to read a row with a timestamp farther in the future than the year 2262 would overflow and show a date in the 1600s.

This was happening because the printing did a conversion to nanoseconds which caused it to overflow. 