### PR TITLE
fix: Dubious owner error

### DIFF
--- a/internal/kokoro/continuous.sh
+++ b/internal/kokoro/continuous.sh
@@ -47,6 +47,7 @@ set -x
 
 # cd to project dir on Kokoro instance
 cd github/cloud-bigtable-cbt-cli
+git config --global --add safe.directory "$(pwd)/./.git"
 
 go version
 

--- a/internal/kokoro/presubmit.sh
+++ b/internal/kokoro/presubmit.sh
@@ -23,6 +23,7 @@ set -x
 
 # cd to project dir on Kokoro instance
 cd github/cloud-bigtable-cbt-cli
+git config --global --add safe.directory "$(pwd)/./.git"
 
 go version
 


### PR DESCRIPTION
The kokoro build on this [PR](https://github.com/googleapis/cloud-bigtable-cbt-cli/pull/245) is failing with error: 
```
fatal: detected dubious ownership in repository at '/tmpfs/src/github/cloud-bigtable-cbt-cli/./.git'
To add an exception for this directory, call:

    git config --global --add safe.directory /tmpfs/src/github/cloud-bigtable-cbt-cli/./.git
fatal: Could not read from remote repository.
```