### PR TITLE
fix: allow colon in column qualifier

### DIFF
--- a/cbt_test.go
+++ b/cbt_test.go
@@ -178,29 +178,21 @@ func TestParseColumnsFilter(t *testing.T) {
 			),
 		},
 		{
-			in:   "familyA:columnA:cellA",
-			fail: true,
+			in:  "familyA:columnA:cellA",
+			out: bigtable.ChainFilters(bigtable.FamilyFilter("familyA"), bigtable.ColumnFilter("columnA:cellA")),
 		},
 		{
-			in:   "familyA::columnA",
-			fail: true,
+			in:  "familyA::columnA",
+			out: bigtable.ChainFilters(bigtable.FamilyFilter("familyA"), bigtable.ColumnFilter(":columnA")),
+		},
+		{
+			in:  ":",
+			out: bigtable.ColumnFilter(""),
 		},
 	}
 
 	for _, tc := range tests {
-		got, err := parseColumnsFilter(tc.in)
-
-		if !tc.fail && err != nil {
-			t.Errorf("parseColumnsFilter(%q) unexpectedly failed: %v", tc.in, err)
-			continue
-		}
-		if tc.fail && err == nil {
-			t.Errorf("parseColumnsFilter(%q) did not fail", tc.in)
-			continue
-		}
-		if tc.fail {
-			continue
-		}
+		got := parseColumnsFilter(tc.in)
 
 		var cmpOpts cmp.Options
 		cmpOpts =
@@ -482,14 +474,14 @@ func TestPrintRowWithHighTimestamp(t *testing.T) {
 	mut := bigtable.NewMutation()
 
 	loc, err := time.LoadLocation("US/Pacific")
-	if (err != nil) {
+	if err != nil {
 		t.Fatalf("Failed to load timezone: %v", err)
 	}
 
 	// a timestamp that is just over int64 max in nanoseconds
 	mut.Set("my-family", "foo", 9223372036855000, []byte("bar"))
 	err = tbl.Apply(ctx, "my-key", mut)
-	if (err != nil) {
+	if err != nil {
 		t.Fatalf("Could not write some rows to prepare the test.")
 	}
 	row, err := tbl.ReadRow(ctx, "my-key")

--- a/cbt_test.go
+++ b/cbt_test.go
@@ -125,9 +125,8 @@ func TestParseArgs(t *testing.T) {
 
 func TestParseColumnsFilter(t *testing.T) {
 	tests := []struct {
-		in   string
-		out  bigtable.Filter
-		fail bool
+		in  string
+		out bigtable.Filter
 	}{
 		{
 			in:  "columnA",


### PR DESCRIPTION
This PR aims to fix https://github.com/googleapis/cloud-bigtable-cbt-cli/issues/296. 

Additionally this changes the behavior `read` or `lookup` commands when `":"` is passed as the `columns` argument. Currently when `":"` is passed, `cbt` reads rows with an empty family and this causes the following server error.
```bash
2026/01/02 20:55:08 Reading row: rpc error: code = InvalidArgument desc = Error in field 'family_name_regex_filter' : argument must not be empty
```

But this PR changes it to read rows with an empty column qualifier, which is allowed to bigtable.