### PR TITLE
fix samplerowkeys output

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -2112,7 +2112,7 @@ func doSampleRowKeys(ctx context.Context, args ...string) {
 	if err != nil {
 		log.Fatalf("Could not sample row keys: %v", err)
 	}
-	for k := range keys {
+	for _, k := range keys {
 		fmt.Println(k)
 	}
 }


### PR DESCRIPTION
Currently the `cbt samplerowkeys` command just prints the index values for the array returned by the `SampleRowKeys` rpc method. This change prints out the actual rowkeys values.