### PR TITLE
fix: print rowkey values instead of array indices for samplerowkeys command

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -2112,7 +2112,7 @@ func doSampleRowKeys(ctx context.Context, args ...string) {
 	if err != nil {
 		log.Fatalf("Could not sample row keys: %v", err)
 	}
-	for k := range keys {
+	for _, k := range keys {
 		fmt.Println(k)
 	}
 }


### PR DESCRIPTION
The `cbt samplerowkeys` command currently doesn't provide any value since it's just printing the index of the slice returned by `SampleRowKeys` rcp method:

```shell
cbt samplerowkeys <table_id>
0
1
2
3
4
5
6
7
...
942
943
944
```