### PR TITLE
chore: replace api-bigtable with bigtable-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*		@googleapis/api-bigtable @triplequark @igorbernstein2
+*		@googleapis/bigtable-team @triplequark @igorbernstein2


### PR DESCRIPTION
This PR replaces @googleapis/api-bigtable with @googleapis/bigtable-team in CODEOWNERS. b/478003109