### PR TITLE
chore: remove outdated cloud-native-db-dpes team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*		@googleapis/bigtable-team @triplequark @igorbernstein2
+*		@googleapis/bigtable-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,5 +11,3 @@ branchProtectionRules:
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
-permissionRules:
-    permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -12,5 +12,4 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
 permissionRules:
-  - team: cloud-native-db-dpes
     permission: admin


### PR DESCRIPTION
Removing outdated cloud-native-db-dpes team from sync-repo-settings.yaml.

This change also removed individual accounts from CODEOWNERS file as Igor is in bigtable-team.

b/481375128