### PR TITLE
fix: escape row keys and column qualifiers in printRow

### DIFF
--- a/cbt.go
+++ b/cbt.go
@@ -1462,7 +1462,7 @@ func printRow(r bigtable.Row, w io.Writer) {
 
 func printRowAtTimezone(r bigtable.Row, w io.Writer, loc *time.Location) {
 	fmt.Fprintln(w, strings.Repeat("-", 40))
-	fmt.Fprintln(w, r.Key())
+	fmt.Fprintf(w, "%q\n", r.Key())
 
 	var fams []string
 	for fam := range r {
@@ -1474,7 +1474,7 @@ func printRowAtTimezone(r bigtable.Row, w io.Writer, loc *time.Location) {
 		sort.Sort(byColumn(ris))
 		for _, ri := range ris {
 			ts := time.UnixMicro(int64(ri.Timestamp))
-			fmt.Fprintf(w, "  %-40s @ %s\n",
+			fmt.Fprintf(w, "  %-40q @ %s\n",
 				ri.Column,
 				ts.In(loc).Format("2006/01/02-15:04:05.000000"))
 			formatted, err :=

--- a/valueformatting_test.go
+++ b/valueformatting_test.go
@@ -571,8 +571,8 @@ func TestJSONAndYAML(t *testing.T) {
 	printRow(row, &out)
 	got := out.String()
 	want := ("----------------------------------------\n" +
-		"r1\n" +
-		"  f1:json\n" +
+		"\"r1\"\n" +
+		"  \"f1:json\"\n" +
 		"    age:     2.00\n" +
 		"    name:   \"Brave\"")
 
@@ -603,8 +603,8 @@ func TestProtobufferAndYAML(t *testing.T) {
 	printRow(row, &out)
 	got := out.String()
 	want := ("----------------------------------------\n" +
-		"r1\n" +
-		"  f1:cat\n" +
+		"\"r1\"\n" +
+		"  \"f1:cat\"\n" +
 		"    name: \"Brave\"\n" +
 		"    age: 2")
 
@@ -650,12 +650,12 @@ func TestPrintRow(t *testing.T) {
 	got := out.String()
 	want :=
 		"----------------------------------------\n" +
-			"r1\n" +
-			"  f1:c1\n" +
+			"\"r1\"\n" +
+			"  \"f1:c1\"\n" +
 			"    \"Hello!\"\n" +
-			"  f1:c2\n" +
+			"  \"f1:c2\"\n" +
 			"    \"\\x01\\x02\"\n" +
-			"  f2:person\n" +
+			"  \"f2:person\"\n" +
 			"    \"\\n\\x03Jim\\x10*\\x1a\\x0fjim@example.com\\\"\\f\\n\\b555-1212\\x10\\x01\"\n" +
 			""
 
@@ -684,12 +684,12 @@ func TestPrintRow(t *testing.T) {
 	globalValueFormatting.setup("")
 
 	want = ("----------------------------------------\n" +
-		"r1\n" +
-		"  f1:c1\n" +
+		"\"r1\"\n" +
+		"  \"f1:c1\"\n" +
 		"    \"Hello!\"\n" +
-		"  f1:c2\n" +
+		"  \"f1:c2\"\n" +
 		"    258\n" +
-		"  f2:person\n" +
+		"  \"f2:person\"\n" +
 		"    name: \"Jim\"\n" +
 		"    id: 42\n" +
 		"    email: \"jim@example.com\"\n" +


### PR DESCRIPTION
Bigtable row keys (<=4 KiB) and column qualifiers (<=16 KiB) are arbitrary byte strings, but printRowAtTimezone wrote them with %s, letting bytes 0x00-0x1F (including ANSI escapes) pass straight to the operator's terminal. Cell values already went through %q; keys and qualifiers were missed. Reachable from doRead, doLookup, and doReadModifyWrite.

Switch both to %q so all three components use the same escape convention. Note: this is a visible output change for cbt read / lookup / readmodifywrite -- keys and columns are now quoted.